### PR TITLE
Update branch name in nrnversion.c

### DIFF
--- a/src/nrnoc/nrnversion.c
+++ b/src/nrnoc/nrnversion.c
@@ -17,7 +17,7 @@ static char configargs[] = NRN_CONFIG_ARGS;
 
 #if !defined(GIT_BRANCH)
 #define GIT_DATE "2018-08-24"
-#define GIT_BRANCH "unknown"
+#define GIT_BRANCH "ime-fix"
 #define GIT_CHANGESET "d3ead4a+"
 #define GIT_DESCRIBE "7.6.2-2-gd3ead4a+"
 #endif


### PR DESCRIPTION
This is a temporary change, just to make sure when we are using the ime-fix branch.