### PR TITLE
Enable only selected builds on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,11 @@ workflows:
   build-workflow:
     jobs:
       - manylinux2014-aarch64:
+          filters:
+            branches:
+              only:
+                - /release\/.*/
+                - /circleci\/.*/
           matrix:
             parameters:
               NRN_PYTHON_VERSION: ["310"]


### PR DESCRIPTION
Due to limited credits, only enable PR builds
when target branch is release/* or circleci/*